### PR TITLE
Increase height of mobile menu

### DIFF
--- a/components/Layout/LayoutMobileMenu.vue
+++ b/components/Layout/LayoutMobileMenu.vue
@@ -2,7 +2,7 @@
   <div class="relative">
     <div
       v-if="!firstRender"
-      class="fixed top-0 left-0 h-[570px] w-screen mt-4 z-0 bg-white animate__animated"
+      class="fixed top-0 left-0 h-[100vh] w-screen mt-4 z-0 bg-white animate__animated"
       :class="{
         animate__fadeInLeft: expandedMenu,
         animate__fadeOutRight: !expandedMenu && !firstRender,


### PR DESCRIPTION
Fixes #1350

Increase the height of the mobile menu to cover the entire page.

* Change the height of the mobile menu from `570px` to `100vh` in `components/Layout/LayoutMobileMenu.vue`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/w3bdesign/nuxtjs-woocommerce/issues/1350?shareId=e6dd2c4d-3e6c-458a-ae19-ae69d9aa819f).