### PR TITLE
Fix mobile menu

### DIFF
--- a/components/Layout/LayoutMobileMenu.vue
+++ b/components/Layout/LayoutMobileMenu.vue
@@ -2,7 +2,7 @@
   <div class="relative">
     <div
       v-if="!firstRender"
-      class="fixed top-0 left-0 h-[calc(100vh-4rem)] w-screen mt-4 z-10 bg-white animate__animated"
+      class="fixed top-0 left-0 h-[calc(100vh-4rem)] w-screen mt-4 z-10 bg-white animate__animated bottom-0 mb-4"
       :class="{
         animate__fadeInLeft: expandedMenu,
         animate__fadeOutRight: !expandedMenu && !firstRender,


### PR DESCRIPTION
Fixes #1354

Add bottom-0 and mb-4 classes to the mobile menu div in `components/Layout/LayoutMobileMenu.vue`.

* Set the mobile menu as fixed and positioned just above the footer with a margin bottom.
* Add `bottom-0` class to the `div` with class `fixed top-0 left-0 h-[calc(100vh-4rem)] w-screen mt-4 z-10 bg-white animate__animated`.
* Add `mb-4` class to the `div` with class `fixed top-0 left-0 h-[calc(100vh-4rem)] w-screen mt-4 z-10 bg-white animate__animated`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/w3bdesign/nuxtjs-woocommerce/issues/1354?shareId=ff8763a8-0a60-4da3-b684-b383c6c2727b).