### PR TITLE
Fix mobile menu positioning

### DIFF
--- a/components/Layout/LayoutMobileMenu.vue
+++ b/components/Layout/LayoutMobileMenu.vue
@@ -2,7 +2,7 @@
   <div class="relative">
     <div
       v-if="!firstRender"
-      class="fixed top-0 left-0 h-[calc(100vh-4rem)] w-screen mt-4 z-10 bg-white animate__animated"
+      class="fixed top-0 left-0 h-[calc(100vh-4rem)] w-screen mt-4 z-10 bg-white animate__animated bottom-0 mb-4"
       :class="{
         animate__fadeInLeft: expandedMenu,
         animate__fadeOutRight: !expandedMenu && !firstRender,


### PR DESCRIPTION
Fixes #1354

Add bottom-0 and mb-4 classes to the mobile menu container to position it just above the footer.

* Modify the mobile menu container class to include `bottom-0` and `mb-4` to ensure it is positioned just above the footer.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/w3bdesign/nuxtjs-woocommerce/issues/1354?shareId=470fd6cd-2f32-4da5-a87f-6240399d99e4).