### PR TITLE
Fix mobile menu positioning

### DIFF
--- a/components/Layout/LayoutMobileMenu.vue
+++ b/components/Layout/LayoutMobileMenu.vue
@@ -2,7 +2,7 @@
   <div class="relative">
     <div
       v-if="!firstRender"
-      class="fixed top-0 left-0 h-[calc(100vh-4rem)] w-screen mt-4 z-10 bg-white animate__animated"
+      class="fixed top-0 left-0 h-[calc(100vh-4rem)] w-screen mt-4 z-10 bg-white animate__animated bottom-0 mb-4"
       :class="{
         animate__fadeInLeft: expandedMenu,
         animate__fadeOutRight: !expandedMenu && !firstRender,


### PR DESCRIPTION
Fixes #1354

Update the mobile menu to be fixed and positioned just above the footer.

* Set the mobile menu as `fixed` with a height of `calc(100vh-4rem)` and add `bottom-0 mb-4` classes to position it just above the footer in `components/Layout/LayoutMobileMenu.vue`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/w3bdesign/nuxtjs-woocommerce/issues/1354?shareId=fa8f35e9-39ef-4af6-a16f-43c101fcb34a).