### PR TITLE
Replace loading text with spinner icon in cart

### DIFF
--- a/components/Layout/LayoutCart.vue
+++ b/components/Layout/LayoutCart.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="mt-4 lg:mt-0">
     <div v-if="isLoading">
-      <span class="text-xl text-gray-500">Loading cart...</span>
+      <Icon
+        name="ri:loader-4-line"
+        size="1.5em"
+        class="text-gray-500 animate-spin"
+      />
     </div>
     <div v-else-if="error">
       <span class="text-xl text-red-500">


### PR DESCRIPTION
Updated the cart loading state to display a spinning loader icon instead of plain text for improved user experience.