### PR TITLE
Increase loader icon size in cart layout

### DIFF
--- a/components/Layout/LayoutCart.vue
+++ b/components/Layout/LayoutCart.vue
@@ -3,7 +3,7 @@
     <div v-if="isLoading">
       <Icon
         name="ri:loader-4-line"
-        size="1.5em"
+        size="2em"
         class="text-gray-500 animate-spin"
       />
     </div>


### PR DESCRIPTION
Updated the loading spinner icon size from 1.5em to 2em in LayoutCart.vue for better visibility during loading states.