### PR TITLE
Add .npmrc and set Renovate minimumReleaseAge

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/renovate.json
+++ b/renovate.json
@@ -44,5 +44,6 @@
         "peerDependencies"
       ]
     }
-  ]
+  ],
+  "minimumReleaseAge": "3 days"
 }


### PR DESCRIPTION
Add .npmrc with ignore-scripts=true to prevent running package lifecycle scripts during installs. Update renovate.json to add "minimumReleaseAge": "3 days" so Renovate will wait before opening PRs for very recent releases, reducing noise and churn.